### PR TITLE
Update BinaryDefense remote info to US-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some of these companies support remote hires. Where that information is availabl
 | :--- | :------- | :----- | :----- | :--------- |
 [Amyris](https://amyris.com/) | USA, CA, Emeryville | Synthetic Biology | [Twitter](https://twitter.com/amyris)
 [Arkadium](https://inhabit.arkadium.com/) | USA, NY / Russia, Krasnodar | Software | [Twitter](https://twitter.com/Arkadium)
-[Binary Defense](https://www.binarydefense.com/) | Akron, OH | Infosec/Endpoint Monitoring | [Twitter](https://twitter.com/binary_defense?lang=en) | Ok
+[Binary Defense](https://www.binarydefense.com/) | USA, OH, Akron | Infosec/Endpoint Monitoring | [Twitter](https://twitter.com/binary_defense?lang=en) | Ok (US only)
 [BinaryGears](https://www.binarygears.de/) | Germany, Frankfurt | Software | [GitHub](https://github.com/ronaldschlenker) | Ok
 [Compositional IT](https://www.compositional-it.com.com) | United Kingdom, London | Software | [GitHub](https://github.com/compositionalit)
 [Cvent](https://www.cvent.com) | USA, VA, McLean | Software | [Github](https://github.com/cvent?utf8=✓&q=&type=&language=f%23)


### PR DESCRIPTION
Right now we can only accept US-based workers, so this should be clarified here so that we don't give the wrong impression.